### PR TITLE
refact: response add exception detail

### DIFF
--- a/src/diting/core/common/openapi.py
+++ b/src/diting/core/common/openapi.py
@@ -1,7 +1,6 @@
 import pydantic
-import logging
 from dataclasses import make_dataclass,field
-logger = logging.getLogger("diting")
+from diting.core.common.log import app_logger as logger
 
 
 def openapi_response_wrapper(model):

--- a/src/diting/core/ddd/base_table.py
+++ b/src/diting/core/ddd/base_table.py
@@ -1,5 +1,3 @@
-import logging
-from copyreg import constructor
 from sqlalchemy.orm import declarative_base
 
 # ----------------------ORM------------------------------------- #

--- a/src/diting/core/ddd/exception.py
+++ b/src/diting/core/ddd/exception.py
@@ -1,8 +1,13 @@
 import logging
+import traceback
 from sanic import Request, Sanic, exceptions, json
 
 app = Sanic.get_app()
 logger = logging.getLogger("diting")
+
+
+def format_exception(exception: Exception):
+    return traceback.format_exception(type(exception), exception, exception.__traceback__)
 
 
 @app.exception(exceptions.NotFound)
@@ -14,7 +19,16 @@ async def not_fount(request: Request, exception: exceptions.SanicException):
     :return:
     """
     logger.error(f"not_fount request=%s exception=%s", request, exception)
-    return json({"code": 404, "detail": str(exception), "data":{}, "message" : "not fund"}, 404)
+    status_code = 404
+    return json(
+        {
+            "code": status_code,
+            "detail": format_exception(exception),
+            "data": {},
+            "msg": "not found",
+        },
+        status_code
+    )
 
 
 @app.exception(exceptions.SanicException)
@@ -30,7 +44,15 @@ async def sanic_exception(request: Request, exception: exceptions.SanicException
         logger.error(f"sanic_exception request=%s, exception=%s", request, exception)
     else:
         logger.exception(f"sanic_exception request=%s, exception=%s", request, exception)
-    return json({"status": status_code, "message": str(exception)}, status_code)
+    return json(
+        {
+            "code": status_code,
+            "detail": format_exception(exception),
+            "data": {},
+            "msg": str(exception),
+        },
+        status_code,
+    )
 
 
 @app.exception(Exception)
@@ -43,4 +65,12 @@ async def base_exception(request: Request, exception: Exception):
     """
     logger.exception(f"base_exception request=%s, exception=%s", request, exception)
     status_code = 500
-    return json({"status": status_code, "message": str(exception)}, status_code)
+    return json(
+        {
+            "code": status_code,
+            "detail": format_exception(exception),
+            "data": {},
+            "msg": str(exception),
+        },
+        status_code,
+    )

--- a/src/diting/core/ddd/exception.py
+++ b/src/diting/core/ddd/exception.py
@@ -1,9 +1,8 @@
-import logging
 import traceback
 from sanic import Request, Sanic, exceptions, json
+from diting.core.common.log import app_logger as logger
 
 app = Sanic.get_app()
-logger = logging.getLogger("diting")
 
 
 def format_exception(exception: Exception):

--- a/src/diting/core/module/redis.py
+++ b/src/diting/core/module/redis.py
@@ -1,4 +1,3 @@
-import logging
 import copy
 import aioredis
 from sanic import Sanic

--- a/src/diting/core/module/scheduler_task.py
+++ b/src/diting/core/module/scheduler_task.py
@@ -1,5 +1,5 @@
 # 封装系统调用的一些逻辑
-import logging
+from diting.core.common.log import app_logger as logger
 from pymysql import Time
 from sanic import Sanic
 from diting.core.common.log import set_logger_level

--- a/src/diting/lrm/entrypoint/cluster_appserv.py
+++ b/src/diting/lrm/entrypoint/cluster_appserv.py
@@ -1,4 +1,3 @@
-import logging
 from diting.lrm.service.cluster_service import ClusterService
 from diting.lrm.message.request import ClusterCreatingRequest, ClusterUpdatingRequest, ClusterListingRequest
 from diting.lrm.message.response import ClusterResponse, ClusterListResponse


### PR DESCRIPTION
```
{
  "code": 404,
  "detail": [
    "Traceback (most recent call last):\n",
    "  File \"handle_request\", line 83, in handle_request\n    )\n",
    "  File \"C:\\Python39\\lib\\site-packages\\sanic_ext\\extras\\serializer\\decorator.py\", line 11, in decorated_function\n    retval = await retval\n",
    "  File \"D:\\code\\ddd-structure\\src\\diting\\lrm\\entrypoint\\cluster_view.py\", line 82, in get_cluster\n    cluster_response = await app_service.get_cluster_by_id(cluster_id)\n",
    "  File \"D:\\code\\ddd-structure\\src\\diting\\lrm\\entrypoint\\cluster_appserv.py\", line 37, in get_cluster_by_id\n    cluster = await self.domainservice.repository.get(cluster_id)\n",
    "  File \"D:\\code\\ddd-structure\\src\\diting\\lrm\\adapter\\cluster_repository.py\", line 38, in get\n    cluster_table = await self._get(cluster_id)\n",
    "  File \"D:\\code\\ddd-structure\\src\\diting\\lrm\\adapter\\cluster_repository.py\", line 45, in _get\n    raise sanic_exception.NotFound(f\"can't find cluster of {cluster_id}\")\n",
    "sanic.exceptions.NotFound: can't find cluster of string\n"
  ],
  "data": {},
  "message": "not found"
}
```



